### PR TITLE
Fix ingress controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Some details about variables for this Kong module.
 | registry | Custom registry host for be used in all the containers | `string` | `""` | no |
 | replica_count | Number of Kong pod replicas if autoscaling is not enable | `string` | `1` | no |
 | resources | Define the limits and/or requests on pod resources | `map(any)` | `{}` | no |
+| ingress_image_tag | Define tag for image ingress controller | `string` | `1.1` | no |
+| ingress_image | Define repository for image ingress controller| `string` | `kong/kubernetes-ingress-controller` | no |
+
 
 #### Outputs
 | Name | Description |

--- a/local.tf
+++ b/local.tf
@@ -3,5 +3,6 @@ locals {
   name              = var.name == "" ? format("kong-%s", random_string.kong_name.0.result) : var.name
   uri_admin_service = format("http://%s-kong-admin.%s.svc:8001", helm_release.kong.metadata.0.name, helm_release.kong.metadata.0.namespace)
   kong_image        = var.registry == "" ? var.kong_image : format("%s/%s", var.registry, var.kong_image)
+  ingress_image     = var.registry == "" ? var.ingress_image : format("%s/%s", var.registry, var.ingress_image)
   bash_image        = var.registry == "" ? var.bash_image : format("%s/%s", var.registry, var.bash_image)
 }

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ resource "helm_release" "kong" {
           ingressClass = local.ingressclass
           installCRDs  = var.ingress_controller_install_crds
           resources    = var.resources
+          image = var.ingress_controller_image
+
         }
         proxy = {
           enabled     = var.enable_proxy_service

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,10 @@ resource "helm_release" "kong" {
           ingressClass = local.ingressclass
           installCRDs  = var.ingress_controller_install_crds
           resources    = var.resources
-          image = var.ingress_controller_image
+          image = {
+            repository = local.ingress_image
+            tag        = var.ingress_image_tag
+          }
 
         }
         proxy = {

--- a/variables.tf
+++ b/variables.tf
@@ -222,6 +222,17 @@ variable "resources" {
   default     = {}
 }
 
+variable "ingress_controller_image" {
+  
+  description = "Define image Ingress Controller"
+  type = map(any)
+  default = {
+            repository = "kong/kubernetes-ingress-controller"
+            tag = "1.1"
+          }
+  
+}
+
 variable "extra_env_configs" {
   description = "Define a list of maps as `[{\"name\"=\"foo\", \"value\"=\"bar\"},]` to configure customs values for kong.conf"
   type        = list(any)

--- a/variables.tf
+++ b/variables.tf
@@ -222,15 +222,15 @@ variable "resources" {
   default     = {}
 }
 
-variable "ingress_controller_image" {
-  
-  description = "Define image Ingress Controller"
-  type = map(any)
-  default = {
-            repository = "kong/kubernetes-ingress-controller"
-            tag = "1.1"
-          }
-  
+variable "ingress_image_tag" {
+  description = "Define tag for image ingress controller"
+  type        = string
+  default     = "1.1"
+}
+variable "ingress_image" {
+  description = "Define name for image ingress controller"
+  type        = string
+  default     = "kong/kubernetes-ingress-controller"
 }
 
 variable "extra_env_configs" {


### PR DESCRIPTION
Kong Ingress Controller image now pulled from Docker Hub (due to Bintray being discontinued). Changed the default Docker image repository for the ingress controller. Due to this, the following error is generated in the version tag 0.1.5,with this changes corrects the error.


```
Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  4m37s                  default-scheduler  Successfully assigned kong/kong-uj84k7y1-kong-85b45fdd8d-8h88v to aged
  Normal   Pulled     4m25s                  kubelet            Container image "kong:2.2.1-alpine" already present on machine
  Normal   Created    4m22s                  kubelet            Created container wait-for-db
  Normal   Started    4m19s                  kubelet            Started container wait-for-db
  Normal   Pulled     3m25s                  kubelet            Container image "kong:2.2.1-alpine" already present on machine
  Normal   Created    3m24s                  kubelet            Created container proxy
  Normal   Started    3m22s                  kubelet            Started container proxy
  Normal   Pulling    2m40s (x3 over 3m29s)  kubelet            Pulling image "kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1"
  Warning  Failed     2m37s (x3 over 3m25s)  kubelet            Failed to pull image "kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1": rpc error: code = Unknown desc = Error response from daemon: error parsing HTTP 403 response body: invalid character '<' looking for beginning of value: "<html>\r\n<head><title>403 Forbidden</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>403 Forbidden</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
  Warning  Failed     2m37s (x3 over 3m25s)  kubelet            Error: ErrImagePull
  Normal   BackOff    2m (x5 over 3m21s)     kubelet            Back-off pulling image "kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1"
  Warning  Failed     2m (x5 over 3m21s)     kubelet            Error: ImagePullBackOff
```
